### PR TITLE
Fix http parsing error when reason-phrase is empty

### DIFF
--- a/aiosonic/__init__.py
+++ b/aiosonic/__init__.py
@@ -115,7 +115,7 @@ class HttpResponse:
 
     def _set_response_initial(self, data: bytes):
         """Parse first bytes from http response."""
-        res = re.match(_HTTP_RESPONSE_STATUS_LINE, data.decode().rstrip())
+        res = re.match(_HTTP_RESPONSE_STATUS_LINE, data.decode().rstrip('\r\n'))
         if not res:
             raise HttpParsingError('response line parsing error')
         self.response_initial = res.groupdict()

--- a/tests/test_aiosonic.py
+++ b/tests/test_aiosonic.py
@@ -537,6 +537,13 @@ def test_parse_response_line():
     assert response.status_code == 200
 
 
+def test_parse_response_line_with_empty_reason():
+    """Test parsing response line with empty reason-phrase"""
+    response = HttpResponse()
+    response._set_response_initial(b'HTTP/1.1 200 \r\n')
+    assert response.status_code == 200
+
+
 def test_parse_bad_response_line():
     """Test parsing bad response line"""
     with pytest.raises(HttpParsingError):


### PR DESCRIPTION
According to RFC7230, the reason-phrase of HTTP Status Line could be empty (but a whitespace after the status code is required). For example, `HTTP/1.1 200 ` is legal.

But in `_set_response_initial` function https://github.com/sonic182/aiosonic/blob/05838de4e38f89f32230552393b6ad3f66b773e0/aiosonic/__init__.py#L118

The `rstrip()` method will remove the last whitespace if the reason-phrase is empty, cause `re.match` failed and then throw a HttpParsingError.
Thus, this commit specifies the characters used in `rstrip()` to fix the problem.