### PR TITLE
Fix wrong case for 'HTTPClient' class name in the index.rst

### DIFF
--- a/sourcedocs/index.rst
+++ b/sourcedocs/index.rst
@@ -55,7 +55,7 @@ Getting Started
   
   
   async def run():
-      client = aiosonic.HttpClient()
+      client = aiosonic.HTTPClient()
   
       # ##################
       # Sample get request


### PR DESCRIPTION
Hello,

I noticed that HTTPClient class name is spelled wrong in the Usage section