### PR TITLE
Fix check for json argument presence in HTTPClient._request_with_body()

### DIFF
--- a/aiosonic/__init__.py
+++ b/aiosonic/__init__.py
@@ -529,7 +529,7 @@ class HTTPClient:
         """Do post http request. """
         if not data and not json:
             TypeError('missing argument, either "json" or "data"')
-        if json:
+        if json is not None:
             data = json_serializer(json)
             headers = headers or HttpHeaders()
             _add_header(headers, 'Content-Type', 'application/json')


### PR DESCRIPTION
Currently it is not possible to pass any falsy value (e.g. empty list) as `json` argument of `post`/`put` methods