### PR TITLE
Fixed missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,7 @@
 
 import re
 from setuptools import setup
-
-
-RGX = re.compile(r"([\w-]+[<>=]{1}=[\d.\w]+)")
+from pkg_resources import parse_requirements
 
 
 def read_file(filename):
@@ -15,7 +13,7 @@ def read_file(filename):
 
 def requirements(filename):
     """Parse requirements from file."""
-    return re.findall(RGX, read_file(filename)) or []
+    return [str(r) for r in parse_requirements(read_file(filename))]
 
 
 def version():


### PR DESCRIPTION
After executing 'pip install aiosonic==0.12.0' command, I found that the 'chardet' dependency was not installed.
Because there was a problem with the dependency resolution regular expression of setup.py. so I fixed it.

---

* As-Is

```bash
aiosonic on  master [⇣?] via aiosonic via 🐍 3.6.14 3.9.6 3.8.11 3.7.11 2.7.18 took 4s
➜ pip install .
Processing /Users/lukas/MyProjects/aiosonic
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
Collecting h2<=4.0.0
  Using cached h2-4.0.0-py3-none-any.whl (57 kB)
Collecting hpack==4.0.0
  Using cached hpack-4.0.0-py3-none-any.whl (32 kB)
Collecting hyperframe==6.0.0
  Using cached hyperframe-6.0.0-py3-none-any.whl (11 kB)
Using legacy 'setup.py install' for aiosonic, since package 'wheel' is not installed.
Installing collected packages: hyperframe, hpack, h2, aiosonic
    Running setup.py install for aiosonic ... done
Successfully installed aiosonic-0.12.0 h2-4.0.0 hpack-4.0.0 hyperframe-6.0.0

aiosonic on  master [⇣?] via aiosonic via 🐍 3.6.14 3.9.6 3.8.11 3.7.11 2.7.18 took 4s
➜ pip list
Package    Version
---------- -------
aiosonic   0.12.0
h2         4.0.0
hpack      4.0.0
hyperframe 6.0.0
pip        21.1.3
setuptools 57.2.0
```

* To-Be

```bash
aiosonic on  master [!?] via aiosonic via 🐍 3.6.14 3.9.6 3.8.11 3.7.11 2.7.18 took 4s
➜ pip install .
Processing /Users/lukas/MyProjects/aiosonic
  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.
Collecting chardet<5.0.0
  Using cached chardet-4.0.0-py2.py3-none-any.whl (178 kB)
Collecting h2<=4.0.0
  Using cached h2-4.0.0-py3-none-any.whl (57 kB)
Collecting hpack<5,>=4.0
  Using cached hpack-4.0.0-py3-none-any.whl (32 kB)
Collecting hyperframe<7,>=6.0
  Downloading hyperframe-6.0.1-py3-none-any.whl (12 kB)
Using legacy 'setup.py install' for aiosonic, since package 'wheel' is not installed.
Installing collected packages: hyperframe, hpack, h2, chardet, aiosonic
    Running setup.py install for aiosonic ... done
Successfully installed aiosonic-0.12.0 chardet-4.0.0 h2-4.0.0 hpack-4.0.0 hyperframe-6.0.1

aiosonic on  master [!?] via aiosonic via 🐍 3.6.14 3.9.6 3.8.11 3.7.11 2.7.18 took 4s
➜ pip list
Package    Version
---------- -------
aiosonic   0.12.0
chardet    4.0.0
h2         4.0.0
hpack      4.0.0
hyperframe 6.0.1
pip        21.1.3
setuptools 57.2.0
```