### PR TITLE
Use HttpHeaders to make case insensitive

### DIFF
--- a/aiosonic/__init__.py
+++ b/aiosonic/__init__.py
@@ -778,7 +778,7 @@ class HTTPClient:
         urlparsed = _get_url_parsed(url)
 
         boundary = None
-        headers = HttpHeaders(headers) if headers else []
+        headers = HttpHeaders(deepcopy(headers)) if headers else []
         body: ParsedBodyType = b""
 
         if self.handle_cookies:

--- a/aiosonic/__init__.py
+++ b/aiosonic/__init__.py
@@ -778,7 +778,7 @@ class HTTPClient:
         urlparsed = _get_url_parsed(url)
 
         boundary = None
-        headers = deepcopy(headers) if headers else []
+        headers = HttpHeaders(headers) if headers else []
         body: ParsedBodyType = b""
 
         if self.handle_cookies:


### PR DESCRIPTION
I found that the 'Content-Type' header is ignored in [_setup_body_request](https://github.com/sonic182/aiosonic/blob/0.13.0/aiosonic/__init__.py#L365-L373) method because user defined headers are not considered CaseInsensitiveDict. So I changed it to be case insensitive.

Please review.