### PR TITLE
Fixed lambda for is_closing in Connection

### DIFF
--- a/aiosonic/connection.py
+++ b/aiosonic/connection.py
@@ -64,7 +64,7 @@ class Connection:
             return True  # noqa
 
         if self.writer:
-            is_closing = lambda: self.writer.is_closing  # type: ignore
+            is_closing = self.writer.is_closing  # type: ignore
 
         dns_info_copy = dns_info.copy()
         dns_info_copy["server_hostname"] = dns_info_copy.pop("hostname")


### PR DESCRIPTION
`is_closing = lambda: ...` will always resolve as `True`. `self.writer.is_closing` is never called.