### PR TITLE
Ensure support for Python 3.11/3.12

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,7 +1,9 @@
 
 name: Python package
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,21 +12,36 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version:
-          - 3.7
-          - 3.8
-          - 3.9
+          - '3.12'
+          - '3.11'
           - '3.10'
+          - '3.9'
+          - '3.8'
+          - '3.7'
+          - 'pypy3.10'
+          - 'pypy3.9'
+          - 'pypy3.8'
+          - 'pypy3.7'
+        exclude:
+          - os: windows-latest
+            python-version: 'pypy3.10'
+          - os: windows-latest
+            python-version: 'pypy3.9'
+          - os: windows-latest
+            python-version: 'pypy3.8'
+          - os: windows-latest
+            python-version: 'pypy3.7'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Use Node.js 12
-        uses: actions/setup-node@v3
+      - name: Install Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 20
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = sourcedocs
 BUILDDIR      = docs
-DOCKER_CMD		= curl -sL https://deb.nodesource.com/setup_14.x | bash && apt-get update && apt-get install nodejs -y && cd /root && cp -r /app/* . && pip install -r requirements.txt && pip install -e \".[test]\" && pytest
+DOCKER_CMD    = curl -sL https://deb.nodesource.com/setup_20.x | bash && apt-get update && apt-get install nodejs -y && cd /root && cp -r /app/* . && pip install -r requirements.txt && pip install -e \".[test]\" && pytest
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -16,17 +16,45 @@ help:
 
 test37:
 	echo "TEST PYTHON 3.7"
-	docker run -i --rm -v $(shell pwd):/app python:3.7 bash -l -c "$(DOCKER_CMD)"
+	docker run -i --rm -v $(shell pwd):/app python:3.7 bash -c "$(DOCKER_CMD)"
 
 test38:
 	echo "TEST PYTHON 3.8"
-	docker run -i --rm -v $(shell pwd):/app python:3.8 bash -l -c "$(DOCKER_CMD)"
+	docker run -i --rm -v $(shell pwd):/app python:3.8 bash -c "$(DOCKER_CMD)"
 
-tes39:
+test39:
 	echo "TEST PYTHON 3.9"
-	docker run -i --rm -v $(shell pwd):/app python:3.9 bash -l -c "$(DOCKER_CMD)"
+	docker run -i --rm -v $(shell pwd):/app python:3.9 bash -c "$(DOCKER_CMD)"
 
-test: test37 test38 test39
+test310:
+	echo "TEST PYTHON 3.10"
+	docker run -i --rm -v $(shell pwd):/app python:3.10 bash -c "$(DOCKER_CMD)"
+
+test311:
+	echo "TEST PYTHON 3.11"
+	docker run -i --rm -v $(shell pwd):/app python:3.11 bash -c "$(DOCKER_CMD)"
+
+test312:
+	echo "TEST PYTHON 3.12"
+	docker run -i --rm -v $(shell pwd):/app python:3.12 bash -c "$(DOCKER_CMD)"
+
+test-pypy37:
+	echo "TEST PYPY 3.7"
+	docker run -i --rm -v $(shell pwd):/app pypy:3.7 bash -c "$(DOCKER_CMD)"
+
+test-pypy38:
+	echo "TEST PYPY 3.8"
+	docker run -i --rm -v $(shell pwd):/app pypy:3.8 bash -c "$(DOCKER_CMD)"
+
+test-pypy39:
+	echo "TEST PYPY 3.9"
+	docker run -i --rm -v $(shell pwd):/app pypy:3.9 bash -c "$(DOCKER_CMD)"
+
+test-pypy310:
+	echo "TEST PYPY 3.10"
+	docker run -i --rm -v $(shell pwd):/app pypy:3.10 bash -c "$(DOCKER_CMD)"
+
+test: test37 test38 test39 test310 test311 test312 test-pypy37 test-pypy38 test-pypy39 test-pypy310
 	echo "OK"
 
 clear:

--- a/setup.py
+++ b/setup.py
@@ -66,13 +66,17 @@ setup(
         "Topic :: Internet :: WWW/HTTP",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    setup_requires=["pytest-runner"],
     install_requires=requirements("./requirements.txt"),
     extras_require={
         "test": add_marks(

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,5 +1,14 @@
 aiodns
-aiohttp
+# regular versions of aiohttp don't support Python 3.12 yet
+# (see https://github.com/aio-libs/aiohttp/issues/7739#issuecomment-1773868351),
+# and pip-compile doesn't support multiple package versions, e.g.
+# aiohttp ; python_version < "3.12"
+# aiohttp==3.9.0b1 ; python_version >= "3.12"
+# so the only option we have at the moment is this:
+aiohttp>=3.9.0b1
+# and still, we have to manually adjust test-requirements.txt
+# to keep support for Python 3.7.
+# (see https://github.com/jazzband/pip-tools/issues/1326)
 asgiref<3.5.0
 black
 coveralls

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,10 +6,13 @@
 #
 aiodns==3.0.0
     # via -r test-requirements.in
-aiohttp==3.8.5
+aiohttp==3.9.0b1 ; python_version >= "3.8"
     # via
+    #   hands :-)
     #   -r test-requirements.in
     #   pytest-aiohttp
+aiohttp==3.8.6 ; python_version < "3.8"
+    # via hands :-)
 aiosignal==1.3.1
     # via aiohttp
 anyio==3.6.2
@@ -56,12 +59,17 @@ django==3.2.20
     # via -r test-requirements.in
 docopt==0.6.2
     # via coveralls
+exceptiongroup==1.1.3
+    # via pytest
 filelock==3.10.6
     # via pytest-mypy
-frozenlist==1.3.3
+frozenlist==1.4.0 ; python_version >= "3.8"
     # via
+    #   hands :-)
     #   aiohttp
     #   aiosignal
+frozenlist==1.3.3 ; python_version < "3.8"
+    # via hands :-)
 h11==0.14.0
     # via
     #   httpcore
@@ -154,7 +162,9 @@ pytz==2023.2
 requests==2.31.0
     # via coveralls
 rfc3986[idna2008]==1.5.0
-    # via httpx
+    # via
+    #   httpx
+    #   rfc3986
 sniffio==1.3.0
     # via
     #   anyio
@@ -166,11 +176,19 @@ termcolor==2.2.0
     # via pytest-sugar
 toml==0.10.2
     # via pytest-black
+tomli==2.0.1
+    # via
+    #   black
+    #   coverage
+    #   mypy
+    #   pytest
 typing-extensions==4.5.0
-    # via mypy
+    # via
+    #   black
+    #   mypy
 urllib3==1.26.15
     # via requests
 uvicorn==0.21.1
     # via -r test-requirements.in
-yarl==1.8.2
+yarl==1.9.2
     # via aiohttp

--- a/tests/test_aiosonic.py
+++ b/tests/test_aiosonic.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import platform
 import ssl
 from urllib.parse import urlparse
 
@@ -489,6 +490,11 @@ async def test_get_chunked_response(app, aiohttp_server):
         await server.close()
 
 
+# TODO: investigate and fix a compatibility issue for PyPy
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason="this test freezes testing on PyPy",
+)
 @pytest.mark.asyncio
 async def test_get_chunked_response_and_not_read_it(app, aiohttp_server):
     """Test get chunked response and not read it.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py36,py37,py38
+envlist = py3{12,11,10,9,8,7},pypy3{10,9,8,7}
+
 [testenv]
 deps=.[test]
-commands=python setup.py test
+allowlist_externals = ./tests.sh
+commands = ./tests.sh -v --cov-append


### PR DESCRIPTION
Hello @sonic182,

I believe it's a great time to declare support for modern Python versions.
So I'd like to propose changes that:
  * enable testing for Python `3.10`-`3.12` and PyPy `3.7`-`3.10`
  * update `classifiers` at `setup.py`
  * fix incompatible test requirements
  * bump [Node.js](https://nodejs.org/en/about/previous-releases) to `20`
  * fix testing with `tox` for Python `3.12`
  * reveal [a PyPy compatibility issue](https://github.com/Jamim/aiosonic/blob/feature/python-support/tests/test_aiosonic.py#L493-L497)

A corresponding test run might be reviewed here:
https://github.com/Jamim/aiosonic/actions/runs/6837246535

Best regards!