### PR TITLE
Fix memory leak in Established Connections

### DIFF
--- a/aiosonic/connection.py
+++ b/aiosonic/connection.py
@@ -133,7 +133,7 @@ class Connection:
             if self.writer and not self.blocked:
                 self.close()
 
-        if not self.blocked:
+        if self.blocked:
             await self.release()
             if self.h2handler:  # pragma: no cover
                 self.h2handler.cleanup()


### PR DESCRIPTION
Established Connections that aren't successfully closed are leaking.

This is due to logical error inside Connection class.

Fix the logical error and the subsequent Connector logic to await the coroutine.

This has a noticeable effect of finally raising ReadTimeout's and RequestTimeout's!