### PR TITLE
Fix pool drain

### DIFF
--- a/aiosonic/__init__.py
+++ b/aiosonic/__init__.py
@@ -222,11 +222,7 @@ class HttpResponse:
 
     def __del__(self):
         # clean it
-        if self.chunked and not self.chunks_readed:
-            loop = None
-            if self.connection:
-                loop = get_loop()
-                loop.create_task(self.connection.release())
+        pass
 
     def _set_request_meta(self, urlparsed: ParseResult):
         self.request_meta = {"from_path": urlparsed.path or "/"}

--- a/aiosonic/connection.py
+++ b/aiosonic/connection.py
@@ -151,7 +151,7 @@ class Connection:
 
             else:
                 while self.blocked:
-                    asyncio_sleep(0.05)
+                    await asyncio_sleep(0.05)
                 if self.cycled:
                     return None
                 elif self.writer and not self.is_closing() and type(self.connector.pool) == CyclicQueuePool:


### PR DESCRIPTION
As I stated previously I have serious problems with the pool draining very quickly. I only tested with CyclicQueuePool,

I erroneously and naively tried to fix this with #452 

It turns out the problem wasn't just an one-liner. The problem starts with create_task in __del__ inside HttpResponse class. This task has no guarantee of executing and as soon __del__ exits the task is most likely instantaneously garbage collected.

So I discovered I could wait inside Connection class __aexit__ function. This alleviated the problem but there was still fast pool drain.

I tried a little more and it became obvious the wait_for call to _do_request helper function was cancelling __aexit__ of Connection class. But I was able to catch CancelledError there so there's guarantee that we can close the socket by using close() on the StreamWriter and finally putting the Connection back into the CyclicQueuePool class Queue.

There was still pool drain so I fixed two more situations inside Connector class where Exceptions happen and the Connection is not put back into the Queue.

Now my crawler is running stable without pool drain! Thank you for the work!