### PR TITLE
Elegant pool drain fix

### DIFF
--- a/aiosonic/__init__.py
+++ b/aiosonic/__init__.py
@@ -223,10 +223,10 @@ class HttpResponse:
     def __del__(self):
         # clean it
         if self.connection and self.connection.blocked:
-             if self.connection.writer:
-                self.connection.writer._transport.abort()
-             self.connection.blocked = False
-             self.connection.connector.pool.release(self.connection)
+            if self.connection.writer:
+               self.connection.writer._transport.abort()
+            self.connection.blocked = False
+            self.connection.connector.pool.release(self.connection)
 
     def _set_request_meta(self, urlparsed: ParseResult):
         self.request_meta = {"from_path": urlparsed.path or "/"}

--- a/aiosonic/__init__.py
+++ b/aiosonic/__init__.py
@@ -222,11 +222,11 @@ class HttpResponse:
 
     def __del__(self):
         # clean it
-        if self.chunked and not self.chunks_readed:
-            loop = None
-            if self.connection:
-                loop = get_loop()
-                loop.create_task(self.connection.release())
+        if self.connection and self.connection.blocked:
+             if self.connection.writer:
+                self.connection.writer._transport.abort()
+             self.connection.blocked = False
+             self.connection.connector.pool.release(self.connection)
 
     def _set_request_meta(self, urlparsed: ParseResult):
         self.request_meta = {"from_path": urlparsed.path or "/"}
@@ -474,6 +474,7 @@ async def _do_request(
             response._set_connection(connection)
         else:
             connection.keep = False
+            response._set_connection(connection)
 
         return response
 

--- a/aiosonic/connectors.py
+++ b/aiosonic/connectors.py
@@ -96,6 +96,7 @@ class TCPConnector:
                 timeout=timeouts.sock_connect,
             )
         except TimeoutException:
+            conn.close()
             await self.release(conn)
             raise ConnectTimeout()
         except BaseException as ex:

--- a/aiosonic/connectors.py
+++ b/aiosonic/connectors.py
@@ -88,15 +88,19 @@ class TCPConnector:
             raise ConnectionPoolAcquireTimeout()
 
     async def after_acquire(self, urlparsed, conn, verify, ssl, timeouts, http2):
-        dns_info = await self.__resolve_dns(urlparsed.hostname, urlparsed.port)
 
         try:
+            dns_info = await self.__resolve_dns(urlparsed.hostname, urlparsed.port)
             await wait_for(
                 conn.connect(urlparsed, dns_info, verify, ssl, http2),
                 timeout=timeouts.sock_connect,
             )
         except TimeoutException:
+            await self.release(conn)
             raise ConnectTimeout()
+        except BaseException as ex:
+            await self.release(conn)
+            raise ex
         return conn
 
     async def release(self, conn):

--- a/aiosonic/pools.py
+++ b/aiosonic/pools.py
@@ -18,7 +18,7 @@ class CyclicQueuePool:
         """Acquire connection."""
         return await self.pool.get()
 
-    async def release(self, conn):
+    def release(self, conn):
         """Release connection."""
         return self.pool.put_nowait(conn)
 

--- a/aiosonic/pools.py
+++ b/aiosonic/pools.py
@@ -32,7 +32,7 @@ class CyclicQueuePool:
     async def cleanup(self):
         """Get all conn and close them, this method let this pool unusable."""
         for _ in range(self.pool_size):
-            conn = self.pool.get()
+            conn = self.pool.get_nowait()
             conn.close()
 
 


### PR DESCRIPTION
This fixes the Pool draining fast issue I've been having with aiosonic in a more elegant manner than my previous PRs.

The first commit fixes edge cases where Connector doesn't put Connection back into pool during errors.

The second commit converts CyclicQueuePool release method to blocking (i.e. non-async) since it only does that one put_nowait() call and that itself is non-blocking.

Finally, the third commit gets rid of create_task with no guarantee of execution in HttpResponse __del__ and instead calls the Pool release directly in a blocking context thanks to the magic of the second commit.

Third commit also adds Connection to Response regardless of keep-alive set. While this may seem overblown, I'm pretty sure I saw some edge cases of Connection Blocked without Keep-Alive set (misconfigured Servers?)