### PR TITLE
Set connection.reader to None on Transport Abort

### DIFF
--- a/aiosonic/connection.py
+++ b/aiosonic/connection.py
@@ -209,6 +209,7 @@ class Connection:
         if self.blocked:
             if self.writer:
                 self.writer._transport.abort()
+                self.reader = None
             self.blocked = False
             self.release()
 


### PR DESCRIPTION
My crawler outputs a lot of the following:
`RuntimeError: readuntil() called while another coroutine is already waiting for incoming data `

The one-line fix now raises a more proper exception:
`MissingReaderException: reader not set.`