### PR TITLE
Prevent Connection.close() from being called twice

### DIFF
--- a/aiosonic/__init__.py
+++ b/aiosonic/__init__.py
@@ -87,7 +87,7 @@ class HttpResponse:
       * **raw_headers** (List[Tuple[bytes, bytes]]): headers as raw format
     """
 
-    def __init__(self):
+    def __init__(self, loop: asyncio.AbstractEventLoop):
         self.headers = HttpHeaders()
         self.cookies = None
         self.raw_headers = []
@@ -98,6 +98,7 @@ class HttpResponse:
         self.compressed = b""
         self.chunks_readed = False
         self.request_meta = {}
+        self.loop = loop
 
     def _set_response_initial(self, data: bytes):
         """Parse first bytes from http response."""
@@ -222,13 +223,16 @@ class HttpResponse:
             self.chunks_readed = True
         finally:
             # Ensure the conn get's released
-            self._connection.release()
-            self._connection = None
+            if self._connection.blocked:
+                await self._connection.release()
+                self._connection = None
 
     def __del__(self):
         # clean it
-        if self._connection:
-            self._connection.ensure_released()
+        if self._connection and self._connection.blocked:
+            clean_up = self.loop.create_task(self._connection.ensure_released())
+            clean_up.add_done_callback(self._connection.background_tasks.discard)
+            self._connection.background_tasks.add(clean_up)
 
     def _set_request_meta(self, urlparsed: ParseResult):
         self.request_meta = {"from_path": urlparsed.path or "/"}
@@ -448,7 +452,7 @@ async def _do_request(
             else:
                 connection.write(body)
 
-        response = HttpResponse()
+        response = HttpResponse(get_loop())
         response._set_request_meta(urlparsed)
 
         # get response code and version

--- a/aiosonic/__init__.py
+++ b/aiosonic/__init__.py
@@ -99,7 +99,7 @@ class HttpResponse:
         self.compressed = b""
         self.chunks_readed = False
         self.request_meta = {}
-        self.loop = loop
+        self._loop = loop
 
     def _set_response_initial(self, data: bytes):
         """Parse first bytes from http response."""
@@ -231,7 +231,7 @@ class HttpResponse:
     def __del__(self):
         # clean it
         if self._connection and self._connection.blocked:
-            clean_up = self.loop.create_task(self._connection.ensure_released())
+            clean_up = self._loop.create_task(self._connection.ensure_released())
             clean_up.add_done_callback(self._connection.background_tasks.discard)
             self._connection.background_tasks.add(clean_up)
 

--- a/aiosonic/connection.py
+++ b/aiosonic/connection.py
@@ -77,7 +77,7 @@ class Connection:
         http2: bool = False,
     ) -> None:
         """Connect with timeout."""
-        self.verify = verify
+        self._verify = verify
         await self._connect(urlparsed, verify, ssl_context, dns_info, http2)
 
     def write(self, data: bytes):
@@ -182,7 +182,6 @@ class Connection:
         if self.requests_count >= self.connector.conn_max_requests or (
             not self.keep and self.blocked
         ):
-            self.blocked = False
             await self.close()
         # ensure unblock conn object after read
         self.blocked = False
@@ -225,10 +224,6 @@ class Connection:
     ):
         if self.h2handler:  # pragma: no cover
             return await self.h2handler.request(headers, body)
-
-    def __del__(self) -> None:
-        """Cleanup."""
-        pass
 
     async def __aenter__(self):
         """Get connection from pool."""

--- a/aiosonic/http2.py
+++ b/aiosonic/http2.py
@@ -6,7 +6,7 @@ import h2.events
 from aiosonic.exceptions import MissingEvent
 from aiosonic.types import ParsedBodyType
 from aiosonic.utils import get_debug_logger
-from aiosonic.resolver import AsyncResolver, get_loop
+from aiosonic.resolver import get_loop
 
 dlogger = get_debug_logger()
 

--- a/aiosonic/http2.py
+++ b/aiosonic/http2.py
@@ -6,6 +6,7 @@ import h2.events
 from aiosonic.exceptions import MissingEvent
 from aiosonic.types import ParsedBodyType
 from aiosonic.utils import get_debug_logger
+from aiosonic.resolver import AsyncResolver, get_loop
 
 dlogger = get_debug_logger()
 
@@ -72,7 +73,7 @@ class Http2Handler(object):
         res = self.requests[stream_id].copy()
         del self.requests[stream_id]
 
-        response = HttpResponse()
+        response = HttpResponse(get_loop())
         for key, val in res["headers"]:
             if key == b":status":
                 response.response_initial = {"version": b"2", "code": val}

--- a/tests/test_aiosonic.py
+++ b/tests/test_aiosonic.py
@@ -22,6 +22,7 @@ from aiosonic.exceptions import (
 )
 from aiosonic.http2 import Http2Handler
 from aiosonic.pools import CyclicQueuePool
+from aiosonic.resolver import AsyncResolver
 from aiosonic.timeout import Timeouts
 
 # setup debug logger

--- a/tests/test_aiosonic.py
+++ b/tests/test_aiosonic.py
@@ -22,7 +22,6 @@ from aiosonic.exceptions import (
 )
 from aiosonic.http2 import Http2Handler
 from aiosonic.pools import CyclicQueuePool
-from aiosonic.resolver import AsyncResolver, get_loop
 from aiosonic.timeout import Timeouts
 
 # setup debug logger
@@ -711,7 +710,7 @@ async def test_request_multipart_value_error():
 @pytest.mark.asyncio
 async def test_json_response_parsing():
     """Test json response parsing."""
-    response = HttpResponse(get_loop())
+    response = HttpResponse(asyncio.get_event_loop())
     response._set_response_initial(b"HTTP/1.1 200 OK\r\n")
     response._set_header("content-type", "application/json; charset=utf-8")
     response.body = b'{"foo": "bar"}'

--- a/tests/test_aiosonic.py
+++ b/tests/test_aiosonic.py
@@ -22,7 +22,7 @@ from aiosonic.exceptions import (
 )
 from aiosonic.http2 import Http2Handler
 from aiosonic.pools import CyclicQueuePool
-from aiosonic.resolver import AsyncResolver
+from aiosonic.resolver import AsyncResolver, get_loop
 from aiosonic.timeout import Timeouts
 
 # setup debug logger
@@ -711,7 +711,7 @@ async def test_request_multipart_value_error():
 @pytest.mark.asyncio
 async def test_json_response_parsing():
     """Test json response parsing."""
-    response = HttpResponse()
+    response = HttpResponse(get_loop())
     response._set_response_initial(b"HTTP/1.1 200 OK\r\n")
     response._set_header("content-type", "application/json; charset=utf-8")
     response.body = b'{"foo": "bar"}'

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,10 +1,10 @@
 import pytest
 
+from asyncio import get_event_loop
 import aiosonic
 from aiosonic import HTTPClient, HttpHeaders, HttpResponse
 from aiosonic.http_parser import add_header, add_headers
 from aiosonic.exceptions import MissingWriterException
-from aiosonic.resolver import get_loop
 
 
 def test_headers_retrival():
@@ -22,7 +22,7 @@ def test_headers_retrival_common():
 
 def test_headers_parsing():
     """Test parsing header with no value."""
-    parsing = HttpResponse(get_loop())
+    parsing = HttpResponse(get_event_loop())
     parsing._set_header(*HttpHeaders._clear_line(b"Expires: \r\n"))
     assert parsing.raw_headers == [("Expires", "")]
 
@@ -58,7 +58,7 @@ def test_add_header_replace():
 
 def test_encoding_from_header():
     """Test use encoder from header."""
-    response = HttpResponse(get_loop())
+    response = HttpResponse(get_event_loop())
     response._set_response_initial(b"HTTP/1.1 200 OK\r\n")
     response._set_header("content-type", "text/html; charset=utf-8")
     response.body = b"foo"
@@ -73,14 +73,14 @@ def test_encoding_from_header():
 
 def test_parse_response_line():
     """Test parsing response line"""
-    response = HttpResponse(get_loop())
+    response = HttpResponse(get_event_loop())
     response._set_response_initial(b"HTTP/1.1 200 OK\r\n")
     assert response.status_code == 200
 
 
 def test_parse_response_line_with_empty_reason():
     """Test parsing response line with empty reason-phrase"""
-    response = HttpResponse(get_loop())
+    response = HttpResponse(get_event_loop())
     response._set_response_initial(b"HTTP/1.1 200 \r\n")
     assert response.status_code == 200
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,6 +4,7 @@ import aiosonic
 from aiosonic import HTTPClient, HttpHeaders, HttpResponse
 from aiosonic.http_parser import add_header, add_headers
 from aiosonic.exceptions import MissingWriterException
+from aiosonic.resolver import get_loop
 
 
 def test_headers_retrival():
@@ -21,7 +22,7 @@ def test_headers_retrival_common():
 
 def test_headers_parsing():
     """Test parsing header with no value."""
-    parsing = HttpResponse()
+    parsing = HttpResponse(get_loop())
     parsing._set_header(*HttpHeaders._clear_line(b"Expires: \r\n"))
     assert parsing.raw_headers == [("Expires", "")]
 
@@ -57,7 +58,7 @@ def test_add_header_replace():
 
 def test_encoding_from_header():
     """Test use encoder from header."""
-    response = HttpResponse()
+    response = HttpResponse(get_loop())
     response._set_response_initial(b"HTTP/1.1 200 OK\r\n")
     response._set_header("content-type", "text/html; charset=utf-8")
     response.body = b"foo"
@@ -72,14 +73,14 @@ def test_encoding_from_header():
 
 def test_parse_response_line():
     """Test parsing response line"""
-    response = HttpResponse()
+    response = HttpResponse(get_loop())
     response._set_response_initial(b"HTTP/1.1 200 OK\r\n")
     assert response.status_code == 200
 
 
 def test_parse_response_line_with_empty_reason():
     """Test parsing response line with empty reason-phrase"""
-    response = HttpResponse()
+    response = HttpResponse(get_loop())
     response._set_response_initial(b"HTTP/1.1 200 \r\n")
     assert response.status_code == 200
 


### PR DESCRIPTION
Connection.close() is occasionally being called more than once from different code-paths in a most classical concurrency screw-up.

This was discovered after the persistence of RuntimeErrors usually coming from readuntil() awaitables proved tricky to solve.

The commit also ressurects the create_task() method to release Connection on HttpResponse __del__(), though it binds the task strongly to a reference inside the Connection object itself, with the inconvenience that aiosonic must pass a instance of the running loop - __del__() is special and finnicky and will complain about a missing loop otherwise.