### PR TITLE
Ensure aiosonic only close the connection from one place

### DIFF
--- a/aiosonic/connection.py
+++ b/aiosonic/connection.py
@@ -186,15 +186,13 @@ class Connection:
     def ensure_released(self):
         """Ensure the connection is released."""
         if self.blocked:
-            self.blocked = False
             self.release()
 
     def close(self) -> None:
         """Close connection if opened."""
         if self.reader:
             try:
-                if not self.reader._transport.is_closing():
-                    self.writer._transport.abort()
+                self.writer._transport.abort()
             except:
                 pass
 

--- a/aiosonic/connectors.py
+++ b/aiosonic/connectors.py
@@ -96,7 +96,6 @@ class TCPConnector:
                 timeout=timeouts.sock_connect,
             )
         except TimeoutException:
-            conn.close()
             self.release(conn)
             raise ConnectTimeout()
         except BaseException as ex:

--- a/aiosonic/http2.py
+++ b/aiosonic/http2.py
@@ -6,7 +6,6 @@ import h2.events
 from aiosonic.exceptions import MissingEvent
 from aiosonic.types import ParsedBodyType
 from aiosonic.utils import get_debug_logger
-from aiosonic.resolver import get_loop
 
 dlogger = get_debug_logger()
 
@@ -73,7 +72,7 @@ class Http2Handler(object):
         res = self.requests[stream_id].copy()
         del self.requests[stream_id]
 
-        response = HttpResponse(get_loop())
+        response = HttpResponse()
         for key, val in res["headers"]:
             if key == b":status":
                 response.response_initial = {"version": b"2", "code": val}

--- a/tests/test_aiosonic.py
+++ b/tests/test_aiosonic.py
@@ -711,7 +711,7 @@ async def test_request_multipart_value_error():
 @pytest.mark.asyncio
 async def test_json_response_parsing():
     """Test json response parsing."""
-    response = HttpResponse(asyncio.get_event_loop())
+    response = HttpResponse()
     response._set_response_initial(b"HTTP/1.1 200 OK\r\n")
     response._set_header("content-type", "application/json; charset=utf-8")
     response.body = b'{"foo": "bar"}'

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,3 @@
-from asyncio import get_event_loop
-
 import pytest
 
 import aiosonic
@@ -23,7 +21,7 @@ def test_headers_retrival_common():
 
 def test_headers_parsing():
     """Test parsing header with no value."""
-    parsing = HttpResponse(get_event_loop())
+    parsing = HttpResponse()
     parsing._set_header(*HttpHeaders._clear_line(b"Expires: \r\n"))
     assert parsing.raw_headers == [("Expires", "")]
 
@@ -59,7 +57,7 @@ def test_add_header_replace():
 
 def test_encoding_from_header():
     """Test use encoder from header."""
-    response = HttpResponse(get_event_loop())
+    response = HttpResponse()
     response._set_response_initial(b"HTTP/1.1 200 OK\r\n")
     response._set_header("content-type", "text/html; charset=utf-8")
     response.body = b"foo"
@@ -74,14 +72,14 @@ def test_encoding_from_header():
 
 def test_parse_response_line():
     """Test parsing response line"""
-    response = HttpResponse(get_event_loop())
+    response = HttpResponse()
     response._set_response_initial(b"HTTP/1.1 200 OK\r\n")
     assert response.status_code == 200
 
 
 def test_parse_response_line_with_empty_reason():
     """Test parsing response line with empty reason-phrase"""
-    response = HttpResponse(get_event_loop())
+    response = HttpResponse()
     response._set_response_initial(b"HTTP/1.1 200 \r\n")
     assert response.status_code == 200
 


### PR DESCRIPTION
Issue #473 is still present, just not very often like it used to be. PR #474 was a first try at getting rid of every RuntimeError possible. It alleviated the problem but it seems it is a smarter choice to only really try to forcefully end the connection from Connection._connect() and only when needed, i.e. a close to begin a new connection.