### PR TITLE
Enable delayed annotations evaluation

### DIFF
--- a/aiosonic/base_client.py
+++ b/aiosonic/base_client.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Optional
 
 from aiosonic.client import HTTPClient

--- a/aiosonic/client.py
+++ b/aiosonic/client.py
@@ -1,5 +1,6 @@
 """Main module."""
 
+from __future__ import annotations
 import asyncio
 import logging
 import os

--- a/aiosonic/connection.py
+++ b/aiosonic/connection.py
@@ -1,5 +1,6 @@
 """Connection stuffs."""
 
+from __future__ import annotations
 import asyncio
 import ssl
 import time

--- a/aiosonic/connectors.py
+++ b/aiosonic/connectors.py
@@ -1,5 +1,6 @@
 """Connector stuffs."""
 
+from __future__ import annotations
 import random
 from asyncio import sleep as asyncio_sleep
 from asyncio import wait_for
@@ -80,7 +81,7 @@ class TCPConnector:
         if self.use_dns_cache:
             self.cache = ExpirableCache(512, ttl_dns_cache)
 
-    async def acquire(self, urlparsed: ParseResult, verify, ssl, timeouts, http2) -> "Connection":
+    async def acquire(self, urlparsed: ParseResult, verify, ssl, timeouts, http2) -> Connection:
         """Acquire a connection from the appropriate pool."""
         if not urlparsed.hostname:
             raise HttpParsingError("missing hostname")

--- a/aiosonic/http2.py
+++ b/aiosonic/http2.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, AsyncIterator, Dict, Iterator, List, Optional, Union
 
@@ -60,7 +61,7 @@ def _resolve_body(request: dict) -> Union[bytes, AsyncIterator[bytes], Iterator[
     return b""
 
 
-def _build_response(res: dict, queue, sem_release, flow_cb) -> "aiosonic.HttpResponse":
+def _build_response(res: dict, queue, sem_release, flow_cb) -> aiosonic.HttpResponse:
     from aiosonic import HttpResponse
 
     response = HttpResponse()
@@ -85,7 +86,7 @@ class Http2Handler(object):
     stream lifetime.
     """
 
-    def __init__(self, connection: "Connection"):
+    def __init__(self, connection: Connection):
         assert connection
         self.connection = connection
         h2conn = connection.h2conn
@@ -162,7 +163,7 @@ class Http2Handler(object):
     def _deregister_stream(self, stream_id: int) -> dict:
         return self.requests.pop(stream_id, {})
 
-    async def request(self, headers: "aiosonic.HeadersType", body: Optional[ParsedBodyType]):
+    async def request(self, headers: aiosonic.HeadersType, body: Optional[ParsedBodyType]):
         if getattr(self, "_closing", False):
             raise ConnectionDisconnected()
 

--- a/aiosonic/http_parser.py
+++ b/aiosonic/http_parser.py
@@ -1,5 +1,6 @@
 """Pure python HTTP parser."""
 
+from __future__ import annotations
 from typing import TYPE_CHECKING, AsyncIterator, Dict, Iterator, List
 from urllib.parse import ParseResult, urlencode, urlparse
 
@@ -35,13 +36,13 @@ async def parse_headers_iterator(connection: Connection):
         yield res_data
 
 
-def headers_iterator(headers: "HeadersType"):
+def headers_iterator(headers: HeadersType):
     iterator = headers if isinstance(headers, List) else headers.items()
     for key, data in iterator:
         yield key, data
 
 
-def add_header(headers: "HeadersType", key: str, value: str, replace=False):
+def add_header(headers: HeadersType, key: str, value: str, replace=False):
     """Safe add header method."""
     if isinstance(headers, List):
         if replace:
@@ -53,14 +54,14 @@ def add_header(headers: "HeadersType", key: str, value: str, replace=False):
         headers[key] = value
 
 
-def add_headers(headers: "HeadersType", headers_to_add: "HeadersType"):
+def add_headers(headers: HeadersType, headers_to_add: HeadersType):
     """Safe add multiple headers."""
     for key, data in headers_iterator(headers_to_add):
         replace = key.lower() in REPLACEABLE_HEADERS
         add_header(headers, key, data, replace)
 
 
-def setup_body_request(data: DataType, headers: "HeadersType") -> ParsedBodyType:
+def setup_body_request(data: DataType, headers: HeadersType) -> ParsedBodyType:
     """Get body to be sent."""
 
     if isinstance(data, (AsyncIterator, Iterator)):

--- a/aiosonic/multipart.py
+++ b/aiosonic/multipart.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 from io import IOBase
 from os.path import basename

--- a/aiosonic/pools.py
+++ b/aiosonic/pools.py
@@ -1,5 +1,6 @@
 """Pools module."""
 
+from __future__ import annotations
 import time
 from abc import ABC, abstractmethod
 from asyncio import Queue, Semaphore, wait_for

--- a/aiosonic/proxy.py
+++ b/aiosonic/proxy.py
@@ -1,5 +1,6 @@
 """Proxy class to be used in client."""
 
+from __future__ import annotations
 from base64 import b64encode
 from typing import Optional
 

--- a/aiosonic/resolver.py
+++ b/aiosonic/resolver.py
@@ -1,5 +1,6 @@
 # copied from aiohttp
 
+from __future__ import annotations
 import asyncio
 import socket
 from abc import ABC, abstractmethod

--- a/aiosonic/sse_client.py
+++ b/aiosonic/sse_client.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 from json import dumps as json_dumps
 from ssl import SSLContext

--- a/aiosonic/sse_config.py
+++ b/aiosonic/sse_config.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Union
 
@@ -15,7 +16,7 @@ class RequestConfig:
     retry_delay: int = 3000
     keep_connection: bool = False
 
-    def with_headers_copy(self) -> "RequestConfig":
+    def with_headers_copy(self) -> RequestConfig:
         new = RequestConfig(
             method=self.method,
             url=self.url,

--- a/aiosonic/tcp_helpers.py
+++ b/aiosonic/tcp_helpers.py
@@ -1,5 +1,6 @@
 """Helper methods to tune a TCP connection"""
 
+from __future__ import annotations
 import socket
 from contextlib import suppress
 from typing import Optional  # noqa

--- a/aiosonic/timeout.py
+++ b/aiosonic/timeout.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Optional
 
 

--- a/aiosonic/types.py
+++ b/aiosonic/types.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import (
     AsyncIterator,
     Dict,

--- a/aiosonic/web_socket_client.py
+++ b/aiosonic/web_socket_client.py
@@ -30,6 +30,7 @@ Exceptions:
         Raised when a read operation times out.
 """
 
+from __future__ import annotations
 import asyncio
 import base64
 import hashlib
@@ -71,7 +72,7 @@ class Message:
     opcode: int
 
     @classmethod
-    def create_text(cls, data: str) -> "Message":
+    def create_text(cls, data: str) -> Message:
         return cls(
             type=MessageType.TEXT,
             data=data,
@@ -80,7 +81,7 @@ class Message:
         )
 
     @classmethod
-    def create_binary(cls, data: bytes) -> "Message":
+    def create_binary(cls, data: bytes) -> Message:
         return cls(
             type=MessageType.BINARY,
             data=data,


### PR DESCRIPTION
This commit enables delayed evaluation of type hints to save some CPU cycles during import and runtime execution at python 3.10 .. 3.13.

Note: As of python 3.14 execution is delayed by default.