### PR TITLE
fix: patch credential leak, CRLF injection, and decompression-bomb DoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] 2026-07-22
+
+### Security
+- Fixed Cookie and Proxy-Authorization headers being forwarded unchanged to a cross-host redirect target when `follow=True` (only `Authorization` was previously stripped). (GHSA-wgrq-f894-59q5)
+- Fixed missing CR/LF validation on outbound header names/values, which allowed HTTP header injection and request splitting via attacker-influenced header values. Added `http_parser.validate_header()`, enforced in both the HTTP/1.1 client and the WebSocket handshake. (GHSA-86v3-rrw9-q5mg)
+- Fixed unbounded gzip/deflate response decompression, which allowed a malicious server to exhaust client memory with a small high-ratio compressed payload. Decompression is now streamed through `zlib.decompressobj()` with a configurable size limit (`HTTPClient(max_decompressed_size=...)`, 100MB default), raising the new `DecompressionError` on overflow. (GHSA-5x59-6wvc-88hg)
+
 ## [1.0.2] 2026-07-15
 
 ### Fixed
@@ -434,7 +441,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - https
 
 
-[Unreleased]: https://github.com/sonic182/aiosonic/compare/1.0.2..HEAD
+[Unreleased]: https://github.com/sonic182/aiosonic/compare/1.0.3..HEAD
+[1.0.3]: https://github.com/sonic182/aiosonic/compare/1.0.2..1.0.3
 [1.0.2]: https://github.com/sonic182/aiosonic/compare/1.0.1..1.0.2
 [1.0.1]: https://github.com/sonic182/aiosonic/compare/1.0.0..1.0.1
 [1.0.0]: https://github.com/sonic182/aiosonic/compare/0.31.1..1.0.0

--- a/aiosonic/client.py
+++ b/aiosonic/client.py
@@ -10,7 +10,6 @@ from asyncio import wait_for
 from codecs import lookup
 from copy import deepcopy
 from functools import partial
-from gzip import decompress as gzip_decompress
 from http import cookies
 from io import IOBase
 from json import dumps as json_dumps
@@ -20,7 +19,7 @@ from random import randint
 from ssl import SSLContext
 from typing import AsyncIterator, Callable, Dict, Iterator, List, Optional, Tuple, Union
 from urllib.parse import ParseResult, urlencode, urljoin
-from zlib import decompress as zlib_decompress
+from zlib import MAX_WBITS, decompressobj
 
 from charset_normalizer import detect
 
@@ -30,6 +29,7 @@ from aiosonic.connectors import TCPConnector
 from aiosonic.exceptions import (
     ConnectionDisconnected,
     ConnectTimeout,
+    DecompressionError,
     HttpParsingError,
     MaxRedirects,
     MissingWriterException,
@@ -56,6 +56,9 @@ _CHUNK_SIZE = 1024 * 4  # 4kilobytes
 CRLF = "\r\n"
 dlogger = get_debug_logger()
 RANDOM_RANGE = (10**8, 10**9)
+_DEFAULT_MAX_DECOMPRESSED_SIZE = 100 * 1024 * 1024  # 100MB
+_GZIP_WBITS = MAX_WBITS | 16
+_DEFLATE_WBITS = MAX_WBITS
 
 REPLACEABLE_HEADERS = {"host", "user-agent"}
 
@@ -80,6 +83,17 @@ class HttpHeaders(CaseInsensitiveDict):
 HeadersType = Union[Dict[str, str], List[Tuple[str, str]], HttpHeaders]
 
 
+def _decompress_bounded(data: bytes, wbits: int, max_size: int) -> bytes:
+    """Stream-decompress data, raising DecompressionError if output would exceed max_size."""
+    decompressor = decompressobj(wbits)
+    out = decompressor.decompress(data, max_size + 1)
+    if not decompressor.unconsumed_tail:
+        out += decompressor.flush()
+    if len(out) > max_size:
+        raise DecompressionError(f"decompressed response body exceeds the {max_size} byte limit")
+    return out
+
+
 class HttpResponse:
     """Custom HttpResponse class for handling responses.
 
@@ -102,6 +116,7 @@ class HttpResponse:
         self.compressed = b""
         self.chunks_readed = False
         self.request_meta = {}
+        self.max_decompressed_size = _DEFAULT_MAX_DECOMPRESSED_SIZE
         self._h2_chunk_queue = None
         self._h2_sem_release = None
         self._h2_flow_cb = None
@@ -171,9 +186,9 @@ class HttpResponse:
     def _set_body(self, data):
         """Set body."""
         if self.compressed == "gzip":
-            self.body += gzip_decompress(data)
+            self.body += _decompress_bounded(data, _GZIP_WBITS, self.max_decompressed_size)
         elif self.compressed == "deflate":
-            self.body += zlib_decompress(data)
+            self.body += _decompress_bounded(data, _DEFLATE_WBITS, self.max_decompressed_size)
         else:
             self.body += data
 
@@ -493,6 +508,7 @@ async def _do_request(
     http2: bool = False,
     proxy: Optional[Proxy] = None,
     transfer_chunked: bool = True,
+    max_decompressed_size: int = _DEFAULT_MAX_DECOMPRESSED_SIZE,
 ) -> HttpResponse:
     """Something."""
     timeouts = timeouts or connector.timeouts
@@ -532,6 +548,7 @@ async def _do_request(
 
         response = HttpResponse()
         response._set_request_meta(urlparsed)
+        response.max_decompressed_size = max_decompressed_size
 
         # get response code and version
         try:
@@ -585,6 +602,11 @@ class HTTPClient:
         * **http2_config**: HTTP/2 protocol tuning (flow-control window, max
             concurrent streams), used only when this client builds its own
             connector (i.e. when ``connector`` is not provided).
+        * **max_decompressed_size**: Maximum allowed size, in bytes, of a
+            gzip/deflate-decompressed response body. Protects against
+            decompression-bomb responses from malicious or compromised
+            servers. Defaults to 100MB; raises
+            :class:`aiosonic.exceptions.DecompressionError` if exceeded.
     """
 
     def __init__(
@@ -596,6 +618,7 @@ class HTTPClient:
         max_redirects: int = 5,
         http2: bool = False,
         http2_config: Optional[Http2Config] = None,
+        max_decompressed_size: int = _DEFAULT_MAX_DECOMPRESSED_SIZE,
     ):
         """Initialize client options."""
         self.connector = connector or TCPConnector(http2=http2, http2_config=http2_config)
@@ -605,6 +628,7 @@ class HTTPClient:
         self.proxy = proxy
         self.max_redirects = max_redirects
         self.http2 = http2
+        self.max_decompressed_size = max_decompressed_size
 
     async def __aenter__(self):
         return self
@@ -783,6 +807,7 @@ class HTTPClient:
         follow: bool = False,
         http2: bool = False,
         max_redirects: Optional[int] = None,
+        max_decompressed_size: Optional[int] = None,
     ) -> HttpResponse:
         """Do http request.
 
@@ -799,6 +824,8 @@ class HTTPClient:
             * **ssl**: this parameter allows to specify a custom ssl context
             * **timeouts**: parameter to indicate timeouts for request
             * **follow**: parameter to indicate whether to follow redirects
+            * **max_decompressed_size**: overrides the client's configured
+              gzip/deflate decompressed-size limit for this request
             * **http2**: flag to indicate whether to use http2 (experimental)
         """
         headers = deepcopy(headers) if headers else HttpHeaders()
@@ -835,6 +862,9 @@ class HTTPClient:
             body = http_parser.setup_body_request(data, headers)
 
         max_redirects = max_redirects if max_redirects is not None else self.max_redirects
+        max_decompressed_size = (
+            max_decompressed_size if max_decompressed_size is not None else self.max_decompressed_size
+        )
         # if class or request method has false, it will be false
         verify_ssl = verify and self.verify_ssl
         http2 = http2 or self.http2
@@ -863,6 +893,7 @@ class HTTPClient:
                         http2,
                         self.proxy,
                         transfer_chunked=transfer_chunked,
+                        max_decompressed_size=max_decompressed_size,
                     ),
                     timeout=(timeouts or self.connector.timeouts).request_timeout,
                 )
@@ -952,11 +983,11 @@ class HTTPClient:
             # to disallow re-sends unless user opts in.
             pass
 
-        # 7) security: drop Authorization when host changes
+        # 7) security: drop Authorization/Cookie/Proxy-Authorization when host changes
         try:
             if current_urlparsed.netloc != new_urlparsed.netloc:
                 for h in list(headers.keys()):
-                    if h.lower() == "authorization":
+                    if h.lower() in ("authorization", "cookie", "proxy-authorization"):
                         del headers[h]
         except Exception:
             pass

--- a/aiosonic/exceptions.py
+++ b/aiosonic/exceptions.py
@@ -58,3 +58,8 @@ class SSEConnectionError(Exception):
 
 class SSEParsingError(Exception):
     pass
+
+
+# Decompression
+class DecompressionError(Exception):
+    pass

--- a/aiosonic/http_parser.py
+++ b/aiosonic/http_parser.py
@@ -1,6 +1,7 @@
 """Pure python HTTP parser."""
 
 from __future__ import annotations
+import re
 from typing import TYPE_CHECKING, AsyncIterator, Dict, Iterator, List
 from urllib.parse import ParseResult, urlencode, urlparse
 
@@ -14,6 +15,17 @@ if TYPE_CHECKING:
 
 REPLACEABLE_HEADERS = {"host", "user-agent"}
 _LRU_CACHE_SIZE = 512
+
+_TOKEN_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_BAD_VALUE_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
+
+
+def validate_header(key: str, value: str) -> None:
+    """Reject header names/values that could enable CRLF injection or request splitting."""
+    if not (key.startswith(":") or _TOKEN_RE.match(key)):
+        raise ValueError(f"invalid header name: {key!r}")
+    if _BAD_VALUE_RE.search(str(value)):
+        raise ValueError(f"invalid header value for {key!r}: contains a disallowed control character")
 
 
 # Functions with cache
@@ -44,6 +56,7 @@ def headers_iterator(headers: HeadersType):
 
 def add_header(headers: HeadersType, key: str, value: str, replace=False):
     """Safe add header method."""
+    validate_header(key, value)
     if isinstance(headers, List):
         if replace:
             included = [item for item in headers if item[0].lower() == key.lower()]

--- a/aiosonic/web_socket_client.py
+++ b/aiosonic/web_socket_client.py
@@ -422,6 +422,9 @@ class WebSocketClient:
         if headers:
             base_headers.update(headers)
 
+        for k, v in base_headers.items():
+            http_parser.validate_header(k, v)
+
         path = urlparsed.path or "/"
         if urlparsed.query:
             path = f"{path}?{urlparsed.query}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiosonic"
-version = "1.0.2"
+version = "1.0.3"
 description = "Async HTTP/WebSocket client"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_aiosonic_ws.py
+++ b/tests/test_aiosonic_ws.py
@@ -134,6 +134,17 @@ async def test_ws_custom_headers(ws_serv):
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(30)
+async def test_ws_connect_rejects_crlf_in_headers(ws_serv):
+    """Test WebSocket connect rejects CRLF injection in header values."""
+    headers = {"X-Evil": "a\r\nX-Injected: 1"}
+
+    async with WebSocketClient() as client:
+        with pytest.raises(ValueError):
+            await client.connect(ws_serv, headers=headers)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
 async def test_ws_drop_frames(ws_serv):
     """Test drop_frames: extra frames dropped, queue doesn't grow."""
     # Use small queues and enable drop mode.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import pytest
 
 import aiosonic
@@ -55,6 +57,59 @@ def test_add_header_replace():
     assert headers == [("user-agent", "wathever")]
 
 
+def test_add_header_rejects_crlf_in_value():
+    """Test that CRLF in a header value is rejected."""
+    with pytest.raises(ValueError):
+        add_header({}, "X-Trace-Id", "abc\r\nX-Injected: pwned")
+
+
+def test_add_header_rejects_bare_lf_and_cr():
+    """Test that bare LF and bare CR in a header value are each rejected."""
+    with pytest.raises(ValueError):
+        add_header({}, "X-Trace-Id", "abc\ninjected")
+    with pytest.raises(ValueError):
+        add_header({}, "X-Trace-Id", "abc\rinjected")
+
+
+def test_add_header_rejects_invalid_name():
+    """Test that a header name with illegal token characters is rejected."""
+    with pytest.raises(ValueError):
+        add_header({}, "X Bad:Name", "value")
+
+
+def test_add_header_allows_pseudo_header_names():
+    """Test that HTTP/2 pseudo-header names (leading ':') are allowed."""
+    headers = []
+    add_header(headers, ":method", "GET")
+    assert headers == [(":method", "GET")]
+
+
+def test_add_header_allows_normal_values():
+    """Test that ordinary header values, including HTAB, still pass."""
+    headers = {}
+    add_header(headers, "Authorization", "Bearer token")
+    add_header(headers, "Content-Type", "text/html; charset=utf-8")
+    add_header(headers, "X-Tabbed", "value\twith\ttab")
+    assert headers == {
+        "Authorization": "Bearer token",
+        "Content-Type": "text/html; charset=utf-8",
+        "X-Tabbed": "value\twith\ttab",
+    }
+
+
+def test_prepare_request_headers_rejects_crlf_injection(mocker):
+    """Test that the real request-building path rejects CRLF-laden header values."""
+    connection = mocker.MagicMock()
+    connection.h2conn = None
+    with pytest.raises(ValueError):
+        aiosonic.client._prepare_request_headers(
+            url=urlparse("http://127.0.0.1/"),
+            connection=connection,
+            method="GET",
+            headers={"X-Trace-Id": "abc\r\nX-Injected: pwned"},
+        )
+
+
 def test_encoding_from_header():
     """Test use encoder from header."""
     response = HttpResponse()
@@ -97,3 +152,57 @@ def test_hostname_parse():
     hostname = "gnosisespaña.es"
     port = 443
     assert aiosonic.client._get_hostname(hostname, port) == "xn--gnosisespaa-beb.es"
+
+
+def test_handle_redirect_strips_credentials_on_cross_host():
+    """Test that Cookie/Authorization/Proxy-Authorization are dropped on cross-host redirect."""
+    client = aiosonic.HTTPClient()
+    response = HttpResponse()
+    response._set_response_initial(b"HTTP/1.1 302 Found\r\n")
+    response._set_header("location", "http://evil.example/steal")
+
+    headers = {
+        "Cookie": "session=SECRET",
+        "Authorization": "Bearer SECRET",
+        "Proxy-Authorization": "Basic SECRET",
+        "X-Custom": "keep-me",
+    }
+    current = urlparse("http://origin.example/")
+
+    client._handle_redirect(
+        current_urlparsed=current,
+        headers=headers,
+        response=response,
+        max_redirects=5,
+        method="GET",
+        body=b"",
+        transfer_chunked=False,
+    )
+
+    assert "Cookie" not in headers
+    assert "Authorization" not in headers
+    assert "Proxy-Authorization" not in headers
+    assert headers["X-Custom"] == "keep-me"
+
+
+def test_handle_redirect_keeps_credentials_on_same_host():
+    """Test that Cookie is preserved when the redirect stays on the same host."""
+    client = aiosonic.HTTPClient()
+    response = HttpResponse()
+    response._set_response_initial(b"HTTP/1.1 302 Found\r\n")
+    response._set_header("location", "http://origin.example/other")
+
+    headers = {"Cookie": "session=SECRET"}
+    current = urlparse("http://origin.example/")
+
+    client._handle_redirect(
+        current_urlparsed=current,
+        headers=headers,
+        response=response,
+        max_redirects=5,
+        method="GET",
+        body=b"",
+        transfer_chunked=False,
+    )
+
+    assert headers["Cookie"] == "session=SECRET"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,10 +1,12 @@
+import gzip
+import zlib
 from urllib.parse import urlparse
 
 import pytest
 
 import aiosonic
 from aiosonic import HttpHeaders, HttpResponse
-from aiosonic.exceptions import MissingWriterException
+from aiosonic.exceptions import DecompressionError, MissingWriterException
 from aiosonic.http_parser import add_header, add_headers
 
 
@@ -206,3 +208,52 @@ def test_handle_redirect_keeps_credentials_on_same_host():
     )
 
     assert headers["Cookie"] == "session=SECRET"
+
+
+def test_decompress_bounded_gzip_ok():
+    """Test that normal gzip data decompresses correctly under a generous limit."""
+    payload = b"hello world" * 10
+    compressed = gzip.compress(payload)
+    result = aiosonic.client._decompress_bounded(compressed, aiosonic.client._GZIP_WBITS, 10_000)
+    assert result == payload
+
+
+def test_decompress_bounded_deflate_ok():
+    """Test that normal deflate (zlib-wrapped) data decompresses correctly under a generous limit."""
+    payload = b"hello world" * 10
+    compressed = zlib.compress(payload)
+    result = aiosonic.client._decompress_bounded(compressed, aiosonic.client._DEFLATE_WBITS, 10_000)
+    assert result == payload
+
+
+def test_decompress_bounded_gzip_rejects_bomb():
+    """Test that a high-ratio gzip payload is rejected once it would exceed the size limit."""
+    compressed = gzip.compress(b"\x00" * 1_000_000, compresslevel=9)
+    with pytest.raises(DecompressionError):
+        aiosonic.client._decompress_bounded(compressed, aiosonic.client._GZIP_WBITS, 1_000)
+
+
+def test_decompress_bounded_deflate_rejects_bomb():
+    """Test that a high-ratio deflate payload is rejected once it would exceed the size limit."""
+    compressed = zlib.compress(b"\x00" * 1_000_000, level=9)
+    with pytest.raises(DecompressionError):
+        aiosonic.client._decompress_bounded(compressed, aiosonic.client._DEFLATE_WBITS, 1_000)
+
+
+def test_set_body_enforces_max_decompressed_size():
+    """Test that HttpResponse._set_body raises DecompressionError once the configured limit is hit."""
+    response = HttpResponse()
+    response.compressed = "gzip"
+    response.max_decompressed_size = 1_000
+    compressed = gzip.compress(b"\x00" * 1_000_000, compresslevel=9)
+    with pytest.raises(DecompressionError):
+        response._set_body(compressed)
+
+
+def test_http_client_max_decompressed_size_configurable():
+    """Test that HTTPClient exposes a sane default and honors a custom max_decompressed_size."""
+    default_client = aiosonic.HTTPClient()
+    assert default_client.max_decompressed_size == aiosonic.client._DEFAULT_MAX_DECOMPRESSED_SIZE
+
+    custom_client = aiosonic.HTTPClient(max_decompressed_size=42)
+    assert custom_client.max_decompressed_size == 42


### PR DESCRIPTION
Addresses three security advisories filed against aiosonic <= 1.0.1:

- GHSA-wgrq-f894-59q5: Cookie and Proxy-Authorization headers were
  forwarded unchanged to the redirect target when a follow=True
  request crossed to a different host — only Authorization was
  stripped. HTTPClient._handle_redirect() now drops all three
  credential-bearing headers on netloc change.

- GHSA-86v3-rrw9-q5mg: Header names/values were interpolated into the
  request line and WebSocket handshake with no validation, letting
  attacker-influenced header values (e.g. a forwarded trace/request
  ID) inject arbitrary headers or a fully smuggled second request via
  embedded CR/LF. Added http_parser.validate_header(), enforced from
  add_header() (covers HTTP/1.1, HTTP/2, multipart, SSE) and from
  WebSocketClient.connect() (its own independent header-serialization
  path, not covered by add_header()).

- GHSA-5x59-6wvc-88hg: Response bodies were decompressed in one shot
  via gzip.decompress()/zlib.decompress() with no output-size limit,
  letting a malicious server exhaust client memory with a small
  high-ratio compressed payload. HttpResponse._set_body() now streams
  through zlib.decompressobj() with a bounded max_length, raising the
  new DecompressionError once output exceeds a configurable limit
  (HTTPClient(max_decompressed_size=...), 100MB default).

All three were reproduced against the vulnerable code before fixing,
and confirmed blocked afterward. New regression tests cover each fix.
