### PR TITLE
Harden workflow, request, and proxy security

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,8 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Use cryptographically secure 128-bit boundaries for both multipart upload paths to prevent practical boundary-guessing part injection.
+
 ## [1.0.3] 2026-07-22
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] 2026-08-04
+
 ### Security
 - Use cryptographically secure 128-bit boundaries for both multipart upload paths to prevent practical boundary-guessing part injection.
 - Strip sensitive credentials when following an HTTPS-to-HTTP redirect, preventing their transmission over plaintext.
@@ -446,7 +448,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - https
 
 
-[Unreleased]: https://github.com/sonic182/aiosonic/compare/1.0.3..HEAD
+[Unreleased]: https://github.com/sonic182/aiosonic/compare/1.0.4..HEAD
+[1.0.4]: https://github.com/sonic182/aiosonic/compare/1.0.3..1.0.4
 [1.0.3]: https://github.com/sonic182/aiosonic/compare/1.0.2..1.0.3
 [1.0.2]: https://github.com/sonic182/aiosonic/compare/1.0.1..1.0.2
 [1.0.1]: https://github.com/sonic182/aiosonic/compare/1.0.0..1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - Use cryptographically secure 128-bit boundaries for both multipart upload paths to prevent practical boundary-guessing part injection.
+- Strip sensitive credentials when following an HTTPS-to-HTTP redirect, preventing their transmission over plaintext.
 
 ## [1.0.3] 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Use cryptographically secure 128-bit boundaries for both multipart upload paths to prevent practical boundary-guessing part injection.
 - Strip sensitive credentials when following an HTTPS-to-HTTP redirect, preventing their transmission over plaintext.
+- Reconnect HTTPS proxy tunnels when the destination origin changes and bind the tunneled TLS handshake to the destination hostname.
 
 ## [1.0.3] 2026-07-22
 

--- a/aiosonic/client.py
+++ b/aiosonic/client.py
@@ -15,7 +15,7 @@ from io import IOBase
 from json import dumps as json_dumps
 from json import loads
 from os.path import basename
-from random import randint
+from secrets import token_hex
 from ssl import SSLContext
 from typing import AsyncIterator, Callable, Dict, Iterator, List, Optional, Tuple, Union
 from urllib.parse import ParseResult, urlencode, urljoin
@@ -55,7 +55,6 @@ _CHARSET_RGX = re.compile(r"charset=(?P<charset>[\w-]*);?")
 _CHUNK_SIZE = 1024 * 4  # 4kilobytes
 CRLF = "\r\n"
 dlogger = get_debug_logger()
-RANDOM_RANGE = (10**8, 10**9)
 _DEFAULT_MAX_DECOMPRESSED_SIZE = 100 * 1024 * 1024  # 100MB
 _GZIP_WBITS = MAX_WBITS | 16
 _DEFLATE_WBITS = MAX_WBITS
@@ -855,7 +854,7 @@ class HTTPClient:
         elif multipart:
             if not isinstance(data, dict):
                 raise ValueError("data should be dict")
-            boundary = "boundary-%d" % randint(*RANDOM_RANGE)
+            boundary = f"boundary-{token_hex(16)}"
             body = await _send_multipart(data, boundary, headers)
             transfer_chunked = False
         elif data:

--- a/aiosonic/client.py
+++ b/aiosonic/client.py
@@ -517,9 +517,12 @@ async def _do_request(
         url_connect = http_parser.get_url_parsed(proxy.host)
 
     connect_ssl = ssl if not proxy else None
+    proxy_target = None
+    if proxy and urlparsed.scheme == "https":
+        proxy_target = (urlparsed.scheme, urlparsed.hostname, urlparsed.port or 443)
 
     args = url_connect, verify, connect_ssl, timeouts, http2
-    async with await connector.acquire(*args) as connection:
+    async with await connector.acquire(*args, proxy_target=proxy_target) as connection:
         if proxy and urlparsed.scheme == "https" and not connection.proxy_connected:
             await _proxy_connect(connection, proxy, urlparsed, ssl or get_default_ssl_context())
 
@@ -1042,18 +1045,25 @@ async def _proxy_connect(connection: Connection, proxy: Proxy, desturl: ParseRes
         raise ConnectionError(f"Failed to establish connection through proxy: {connect_response}")
 
     if sys.version_info >= (3, 11):
-        await connection.upgrade(ssl_context)
+        await connection.upgrade(ssl_context, server_hostname=desturl.hostname)
     else:
         # Manually upgrade the connection to TLS for Python versions < 3.11
-        await _update_transport(connection, ssl_context)
+        await _update_transport(connection, ssl_context, desturl.hostname)
 
     connection.proxy_connected = True
+    connection.proxy_target = (desturl.scheme, desturl.hostname, port)
 
 
-async def _update_transport(connection: Connection, ssl_context):
+async def _update_transport(connection: Connection, ssl_context, server_hostname: Optional[str] = None):
     transport = connection.writer.transport
     protocol = transport.get_protocol()
-    new_transport = await get_loop().start_tls(transport, protocol, ssl_context, server_side=False)
+    new_transport = await get_loop().start_tls(
+        transport,
+        protocol,
+        ssl_context,
+        server_side=False,
+        server_hostname=server_hostname,
+    )
 
     writer = connection.writer
     reader = connection.reader

--- a/aiosonic/client.py
+++ b/aiosonic/client.py
@@ -982,9 +982,10 @@ class HTTPClient:
             # to disallow re-sends unless user opts in.
             pass
 
-        # 7) security: drop Authorization/Cookie/Proxy-Authorization when host changes
         try:
-            if current_urlparsed.netloc != new_urlparsed.netloc:
+            if current_urlparsed.netloc != new_urlparsed.netloc or (
+                current_urlparsed.scheme == "https" and new_urlparsed.scheme != "https"
+            ):
                 for h in list(headers.keys()):
                     if h.lower() in ("authorization", "cookie", "proxy-authorization"):
                         del headers[h]

--- a/aiosonic/connection.py
+++ b/aiosonic/connection.py
@@ -79,6 +79,7 @@ class Connection:
 
         self._verify = True
         self.proxy_connected = False
+        self.proxy_target: Optional[Tuple[str, str, int]] = None
         self.last_released_time = None
 
     @property
@@ -305,13 +306,15 @@ class Connection:
 
             self.reader, self.writer = None, None
         self.proxy_connected = False
+        self.proxy_target = None
 
-    async def upgrade(self, ssl_context: SSLContext = None):
+    async def upgrade(self, ssl_context: SSLContext = None, server_hostname: Optional[str] = None):
         """Upgrade the connection to use TLS.
 
         Args:
             ssl_context (SSLContext, optional): The SSL context to use for the upgrade.
-                If None, a default context will be created. Defaults to None.
+                                              If None, a default context will be created. Defaults to None.
+            server_hostname (Optional[str]): Hostname used for TLS SNI and certificate verification.
 
         Raises:
             MissingWriterException: If the writer is not set.
@@ -319,7 +322,7 @@ class Connection:
         ssl_context = ssl_context or get_default_ssl_context(self._verify)
         if not self.writer:
             raise MissingWriterException()
-        await self.writer.start_tls(ssl_context)
+        await self.writer.start_tls(ssl_context, server_hostname=server_hostname)
 
     async def http2_request(self, headers: Dict[str, str], body: Optional[ParsedBodyType]):
         """Send an HTTP/2 request.

--- a/aiosonic/connectors.py
+++ b/aiosonic/connectors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import random
 from asyncio import sleep as asyncio_sleep
 from asyncio import wait_for
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 from urllib.parse import ParseResult
 
 from onecache import ExpirableCache
@@ -87,7 +87,15 @@ class TCPConnector:
         if self.use_dns_cache:
             self.cache = ExpirableCache(512, ttl_dns_cache)
 
-    async def acquire(self, urlparsed: ParseResult, verify, ssl, timeouts, http2) -> Connection:
+    async def acquire(
+        self,
+        urlparsed: ParseResult,
+        verify,
+        ssl,
+        timeouts,
+        http2,
+        proxy_target: Optional[Tuple[str, str, int]] = None,
+    ) -> Connection:
         """Acquire a connection from the appropriate pool."""
         if not urlparsed.hostname:
             raise HttpParsingError("missing hostname")
@@ -101,6 +109,8 @@ class TCPConnector:
             pool = self.pools[":default"]
 
         conn = await pool.acquire(urlparsed)
+        if proxy_target and conn.proxy_connected and conn.proxy_target != proxy_target:
+            conn.close()
         return await self.after_acquire(urlparsed, conn, verify, ssl, timeouts, http2)
 
     async def after_acquire(self, urlparsed, conn, verify, ssl, timeouts, http2):

--- a/aiosonic/multipart.py
+++ b/aiosonic/multipart.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 import os
 from io import IOBase
 from os.path import basename
-from random import randint
+from secrets import token_hex
 from typing import Optional, Union, cast
 
 from aiosonic.resolver import get_loop
 
-RANDOM_RANGE = (1000, 9999)
 _CHUNK_SIZE = 1024 * 1024  # 1mb
 
 
@@ -119,7 +118,7 @@ class MultipartForm:
     def __init__(self):
         """Initializes an empty list for fields and generates a boundary."""
         self.fields = []
-        self.boundary = f"boundary-{randint(*RANDOM_RANGE)}"
+        self.boundary = f"boundary-{token_hex(16)}"
 
     def add_field(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiosonic"
-version = "1.0.3"
+version = "1.0.4"
 description = "Async HTTP/WebSocket client"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -187,6 +187,38 @@ def test_handle_redirect_strips_credentials_on_cross_host():
     assert headers["X-Custom"] == "keep-me"
 
 
+def test_handle_redirect_strips_credentials_on_https_downgrade():
+    """Test that credentials are dropped when HTTPS redirects to HTTP on the same host."""
+    client = aiosonic.HTTPClient()
+    response = HttpResponse()
+    response._set_response_initial(b"HTTP/1.1 302 Found\r\n")
+    response._set_header("location", "http://origin.example/insecure")
+
+    headers = {
+        "Cookie": "session=SECRET",
+        "Authorization": "Bearer SECRET",
+        "Proxy-Authorization": "Basic SECRET",
+        "X-Custom": "keep-me",
+    }
+    current = urlparse("https://origin.example/secure")
+
+    new_urlparsed, *_ = client._handle_redirect(
+        current_urlparsed=current,
+        headers=headers,
+        response=response,
+        max_redirects=5,
+        method="GET",
+        body=b"",
+        transfer_chunked=False,
+    )
+
+    assert new_urlparsed.scheme == "http"
+    assert "Cookie" not in headers
+    assert "Authorization" not in headers
+    assert "Proxy-Authorization" not in headers
+    assert headers["X-Custom"] == "keep-me"
+
+
 def test_handle_redirect_keeps_credentials_on_same_host():
     """Test that Cookie is preserved when the redirect stays on the same host."""
     client = aiosonic.HTTPClient()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -79,6 +79,37 @@ def test_is_connected_false_before_connect():
     assert not conn.is_connected
 
 
+def test_close_resets_proxy_tunnel_state():
+    """Test closing a connection clears its proxy tunnel state."""
+    from aiosonic.pools import CyclicQueuePool
+
+    pool = CyclicQueuePool(PoolConfig(size=1), Connection)
+    conn = Connection(pool)
+    conn.proxy_connected = True
+    conn.proxy_target = ("https", "second.example", 443)
+
+    conn.close()
+
+    assert not conn.proxy_connected
+    assert conn.proxy_target is None
+
+
+@pytest.mark.asyncio
+async def test_upgrade_passes_server_hostname(mocker):
+    """Test TLS upgrades pass the destination hostname for verification."""
+    from aiosonic.pools import CyclicQueuePool
+
+    pool = CyclicQueuePool(PoolConfig(size=1), Connection)
+    conn = Connection(pool)
+    conn.writer = mocker.MagicMock()
+    conn.writer.start_tls = mocker.AsyncMock()
+    ssl_context = mocker.MagicMock()
+
+    await conn.upgrade(ssl_context, server_hostname="second.example")
+
+    conn.writer.start_tls.assert_awaited_once_with(ssl_context, server_hostname="second.example")
+
+
 @pytest.mark.asyncio
 async def test_write_without_writer():
     from aiosonic.pools import CyclicQueuePool, PoolConfig

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -5,6 +5,16 @@ from aiosonic.client import MultipartFile, _send_multipart
 from aiosonic.multipart import MultipartForm
 
 
+def test_multipartform_uses_cryptographic_boundary(mocker):
+    """Test MultipartForm uses a cryptographically secure boundary."""
+    token_hex = mocker.patch("aiosonic.multipart.token_hex", return_value="a" * 32)
+
+    form = MultipartForm()
+
+    assert form.boundary == f"boundary-{'a' * 32}"
+    token_hex.assert_called_once_with(16)
+
+
 @pytest.mark.asyncio
 async def test_post_multipart(http_serv):
     """Test post multipart."""
@@ -88,6 +98,21 @@ async def test_multipart_backward_compatibility(http_serv):
         res = await client.post(url, data=data, multipart=True)
         assert res.status_code == 200
         assert await res.text() == "bar-foo"
+
+
+@pytest.mark.asyncio
+async def test_legacy_multipart_uses_cryptographic_boundary(http_serv, mocker):
+    """Test legacy multipart uses a cryptographically secure boundary."""
+    token_hex = mocker.patch("aiosonic.client.token_hex", return_value="b" * 32)
+    url = f"{http_serv}/upload_file"
+    data = {"foo": open("tests/files/bar.txt", "rb"), "field1": "foo"}
+
+    async with aiosonic.HTTPClient() as client:
+        res = await client.post(url, data=data, multipart=True)
+        assert res.status_code == 200
+        assert await res.text() == "bar-foo"
+
+    token_hex.assert_called_once_with(16)
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,9 +1,36 @@
 """Test proxy requests."""
 
+from urllib.parse import urlparse
+
 import pytest
 
 from aiosonic import HTTPClient
+from aiosonic.client import _do_request, _proxy_connect, _update_transport
+from aiosonic.connectors import TCPConnector
+from aiosonic.pools import PoolConfig
 from aiosonic.proxy import Proxy
+from aiosonic.timeout import Timeouts
+
+
+class TunnelTrackingConnection:
+    """Connection double that tracks proxy tunnel lifecycle."""
+
+    def __init__(self, pool):
+        self.pool = pool
+        self.key = None
+        self.proxy_connected = True
+        self.proxy_target = ("https", "first.example", 443)
+        self.last_released_time = None
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+        self.proxy_connected = False
+        self.proxy_target = None
+
+
+async def _return_connection(_urlparsed, connection, *_args):
+    return connection
 
 
 @pytest.mark.asyncio
@@ -16,3 +43,114 @@ async def test_proxy_request(http_serv, proxy_serv):
         res = await client.get(url)
         assert await res.text() == "Hello, world"
         assert res.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_https_proxy_request_passes_destination_to_connector(mocker):
+    """Test HTTPS proxy requests identify the destination tunnel origin."""
+    connection = mocker.MagicMock()
+    connection.proxy_connected = False
+    connection.h2conn = object()
+    connection.__aenter__ = mocker.AsyncMock(return_value=connection)
+    connection.__aexit__ = mocker.AsyncMock(return_value=False)
+    connection.http2_request = mocker.AsyncMock(return_value=object())
+    connector = mocker.MagicMock()
+    connector.timeouts = Timeouts()
+    connector.acquire = mocker.AsyncMock(return_value=connection)
+    mocker.patch("aiosonic.client._proxy_connect", new=mocker.AsyncMock())
+
+    await _do_request(
+        urlparse("https://second.example/resource"),
+        lambda **_kwargs: {},
+        connector,
+        None,
+        True,
+        None,
+        Timeouts(),
+        proxy=Proxy("http://proxy.example:8080"),
+    )
+
+    assert connector.acquire.await_args.kwargs["proxy_target"] == ("https", "second.example", 443)
+
+
+@pytest.mark.asyncio
+async def test_connector_reconnects_proxy_tunnel_for_different_origin(mocker):
+    """Test a proxy tunnel is closed before it is reused for another HTTPS origin."""
+    connector = TCPConnector({":default": PoolConfig(size=1)}, connection_cls=TunnelTrackingConnection)
+    mocker.patch.object(connector, "after_acquire", side_effect=_return_connection)
+
+    connection = await connector.acquire(
+        urlparse("http://proxy.example:8080"),
+        True,
+        None,
+        Timeouts(),
+        False,
+        proxy_target=("https", "second.example", 443),
+    )
+
+    assert connection.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_connector_keeps_proxy_tunnel_for_same_origin(mocker):
+    """Test a proxy tunnel remains reusable for its original HTTPS origin."""
+    connector = TCPConnector({":default": PoolConfig(size=1)}, connection_cls=TunnelTrackingConnection)
+    mocker.patch.object(connector, "after_acquire", side_effect=_return_connection)
+
+    connection = await connector.acquire(
+        urlparse("http://proxy.example:8080"),
+        True,
+        None,
+        Timeouts(),
+        False,
+        proxy_target=("https", "first.example", 443),
+    )
+
+    assert connection.close_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_proxy_connect_uses_destination_hostname_for_tls(mocker):
+    """Test CONNECT TLS upgrade uses the destination hostname."""
+    connection = mocker.MagicMock()
+    connection.writer = mocker.MagicMock()
+    connection.writer.drain = mocker.AsyncMock()
+    connection.read = mocker.AsyncMock(return_value=b"HTTP/1.1 200 Connection established\r\n\r\n")
+    connection.upgrade = mocker.AsyncMock()
+    ssl_context = mocker.MagicMock()
+
+    await _proxy_connect(
+        connection,
+        Proxy("http://proxy.example:8080"),
+        urlparse("https://second.example/resource"),
+        ssl_context,
+    )
+
+    connection.upgrade.assert_awaited_once_with(ssl_context, server_hostname="second.example")
+    assert connection.proxy_target == ("https", "second.example", 443)
+
+
+@pytest.mark.asyncio
+async def test_update_transport_uses_destination_hostname(mocker):
+    """Test pre-3.11 TLS upgrades use the destination hostname."""
+    transport = mocker.MagicMock()
+    protocol = mocker.MagicMock()
+    transport.get_protocol.return_value = protocol
+    new_transport = mocker.MagicMock()
+    new_transport.get_protocol.return_value = mocker.MagicMock()
+    connection = mocker.MagicMock()
+    connection.writer.transport = transport
+    ssl_context = mocker.MagicMock()
+    loop = mocker.MagicMock()
+    loop.start_tls = mocker.AsyncMock(return_value=new_transport)
+    mocker.patch("aiosonic.client.get_loop", return_value=loop)
+
+    await _update_transport(connection, ssl_context, "second.example")
+
+    loop.start_tls.assert_awaited_once_with(
+        transport,
+        protocol,
+        ssl_context,
+        server_side=False,
+        server_hostname="second.example",
+    )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,5 +1,6 @@
 """Test proxy requests."""
 
+import sys
 from urllib.parse import urlparse
 
 import pytest
@@ -118,6 +119,9 @@ async def test_proxy_connect_uses_destination_hostname_for_tls(mocker):
     connection.read = mocker.AsyncMock(return_value=b"HTTP/1.1 200 Connection established\r\n\r\n")
     connection.upgrade = mocker.AsyncMock()
     ssl_context = mocker.MagicMock()
+    update_transport = None
+    if sys.version_info < (3, 11):
+        update_transport = mocker.patch("aiosonic.client._update_transport", new=mocker.AsyncMock())
 
     await _proxy_connect(
         connection,
@@ -126,7 +130,10 @@ async def test_proxy_connect_uses_destination_hostname_for_tls(mocker):
         ssl_context,
     )
 
-    connection.upgrade.assert_awaited_once_with(ssl_context, server_hostname="second.example")
+    if sys.version_info >= (3, 11):
+        connection.upgrade.assert_awaited_once_with(ssl_context, server_hostname="second.example")
+    else:
+        update_transport.assert_awaited_once_with(connection, ssl_context, "second.example")
     assert connection.proxy_target == ("https", "second.example", 443)
 
 


### PR DESCRIPTION
closes https://github.com/sonic182/aiosonic/issues/588

## Summary
- grant the CI workflow explicit read-only repository permissions
- generate cryptographically secure multipart boundaries in both multipart upload paths
- strip sensitive credentials on HTTPS-to-HTTP redirects
- reconnect HTTPS proxy tunnels when the destination origin changes and bind inner TLS to the destination hostname

## Root cause
Proxy connections were keyed by the proxy address and a completed CONNECT tunnel was reused for later destinations, leaving requests inside the first origin's TLS stream.

## Validation
- `uv run ruff check aiosonic tests aiosonic_utils`
- `uv run py.test` (196 passed)
- sequential HTTPS smoke test through local pyproxy: packages.sublimetext.com and codeload.github.com both returned 200